### PR TITLE
package.json: change name from papyrus to escriba

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "papyrus",
+  "name": "escriba",
   "version": "1.0.0",
   "description": "Logging with steroids",
   "main": "src/index.js",
@@ -9,14 +9,14 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/pagarme/papyrus.git"
+    "url": "git+https://github.com/pagarme/escriba.git"
   },
   "author": "Pagar.me Pagamentos S/A",
   "license": "MIT",
   "bugs": {
-    "url": "https://github.com/pagarme/papyrus/issues"
+    "url": "https://github.com/pagarme/escriba/issues"
   },
-  "homepage": "https://github.com/pagarme/papyrus#readme",
+  "homepage": "https://github.com/pagarme/escriba#readme",
   "dependencies": {
     "cuid": "^1.3.8",
     "moment-timezone": "^0.5.13",
@@ -30,8 +30,6 @@
     "eslint-plugin-import": "^2.2.0",
     "eslint-plugin-node": "^4.2.2",
     "eslint-plugin-promise": "^3.5.0",
-    "eslint-plugin-standard": "^3.0.1",
-    "log4js": "^1.1.1",
-    "winston": "^2.3.1"
+    "eslint-plugin-standard": "^3.0.1"
   }
 }


### PR DESCRIPTION
we change the name because papyrus isn't available on npm