### PR TITLE
message-builder: log body property always as an object

### DIFF
--- a/src/logger.js
+++ b/src/logger.js
@@ -2,11 +2,10 @@ const R = require('ramda')
 const cuid = require('cuid')
 const { stringify } = require('./utils')
 
-const buildLog = messageBuilder => (message, level, additional) => {
+const buildLog = messageBuilder => (body, level, additional) => {
   const defaultAdditional = R.defaultTo({}, additional)
   const { id, from } = defaultAdditional
-  const log = messageBuilder({ id: R.defaultTo(cuid(), id), message, level, from })
-  return log
+  return messageBuilder({ id: R.defaultTo(cuid(), id), body, level, from })
 }
 
 const createProxyLevels = (buildLog, logger) => {

--- a/src/message-builder.js
+++ b/src/message-builder.js
@@ -11,9 +11,15 @@ const generateDefaultProps = service => ({
 
 const filterMessage = R.filter(prop => !R.isNil(prop))
 
-const builder = (messageMasker, service) => (message, propsToLog) => (
-  filterMessage(messageMasker(R.merge(message, generateDefaultProps(service))))
-)
+const convertBodyToObject = bodyValue => {
+  if (!R.is(Object, bodyValue)) return { message: bodyValue }
+  return bodyValue
+}
+
+const builder = (messageMasker, service) => (message, propsToLog) => {
+  const messageToLog = R.merge(message, { body: convertBodyToObject(message.body) })
+  return filterMessage(messageMasker(R.merge(messageToLog, generateDefaultProps(service))))
+}
 
 const messageBuilder = (messageMasker, service) => (
   builder(messageMasker, service)


### PR DESCRIPTION
Log body property always as object is a way to be Elastic Search friendly.