### PR TITLE
readme: fix example to work properly

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,12 +39,14 @@ const log4js = require('log4js').getLogger()
 const escriba = require('escriba')
 const cuid = require('cuid')
 
+log4js.level = 'info'
+
 const { logger } = escriba({ 
   loggerEngine: log4js, 
   service: 'api',
   sensitive: {
     password: {
-      paths: ['password'],
+      paths: ['message.password'],
       pattern: /\w.*/g,
       replacer: '*'
     }


### PR DESCRIPTION
The README example didn't work to me. This commit do changes in README
example to display the logs correctly.