### PR TITLE
skip-rules: add new engine for skip-rules

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,11 +91,23 @@ const { httpLogger } = escriba({
       response: ['id', 'url', 'body', 'statusCode', 'latency']
     },
     envToLog: ['SHELL', 'PATH'],
-    skipRules: {
-      bannedRoutes: [/\/status.*/],
-      bannedMethods: ['OPTIONS'],
-      bannedBodyRoutes: [/.*\.(csv|xlsx)$/]
-    }
+    skipRules: [
+      {
+        route: /\/status/,
+        method: /.*/,
+        onlyBody: false
+      },
+      {
+        route: /.*\.(csv|xlsx)$/,
+        method: /GET/,
+        onlyBody: true
+      },
+      {
+        route: /.*/,
+        method: /OPTIONS/,
+        onlyBody: false
+      }
+    ]
   }
 })
 
@@ -114,6 +126,8 @@ This id is injected in the `req` object, so if you need to log some extra inform
 ```js
 logger.info('some controller information', { id: req.id })
 ```
+
+Also it's possible to skip logs or only the body property through skipRules, in the example we are skiping logs from route `/status` for `all methods` and skiping the `body` property from routes that ends with `.csv` or `.xlsx`.
 
 ## Examples
 

--- a/src/response-logger.js
+++ b/src/response-logger.js
@@ -68,7 +68,7 @@ const captureLog = (http, propsToLog, skipper, logger, messageBuilder) => {
 }
 
 const responseLogger = (logger, messageBuilder, propsToLog, skipper) => (req, res) => (
-  captureLog({ req , res }, propsToLog, skipper, logger, messageBuilder)
+  captureLog({ req, res }, propsToLog, skipper, logger, messageBuilder)
 )
 
 module.exports = { createResponseLogger: responseLogger }

--- a/src/skipper.js
+++ b/src/skipper.js
@@ -1,0 +1,22 @@
+const { flip, test, reduce } = require('ramda')
+
+const checkRuleBy = property => flip(test)(property)
+
+const skipper = rules => (reqRoute, reqMethod, shouldSkipOnlyBody = false) => {
+  const checkMethod = checkRuleBy(reqMethod)
+  const checkRoute = checkRuleBy(reqRoute)
+
+  const checkRules = (route, method) => (
+    checkRoute(route) && checkMethod(method)
+  )
+
+  const decision = reduce(({ shouldSkip, onlyBody }, rule) => ({
+    shouldSkip: checkRules(rule.route, rule.method) || shouldSkip,
+    onlyBody: checkRules(rule.route, rule.method) && rule.onlyBody || onlyBody
+  }), { shouldSkip: false, onlyBody: false }, rules)
+
+  if (shouldSkipOnlyBody) return decision.shouldSkip && decision.onlyBody
+  return decision.shouldSkip && !decision.onlyBody
+}
+
+module.exports = { createSkipper: skipper }

--- a/src/skipper.js
+++ b/src/skipper.js
@@ -12,7 +12,7 @@ const skipper = rules => (reqRoute, reqMethod, shouldSkipOnlyBody = false) => {
 
   const decision = reduce(({ shouldSkip, onlyBody }, rule) => ({
     shouldSkip: checkRules(rule.route, rule.method) || shouldSkip,
-    onlyBody: checkRules(rule.route, rule.method) && rule.onlyBody || onlyBody
+    onlyBody: (checkRules(rule.route, rule.method) && rule.onlyBody) || onlyBody
   }), { shouldSkip: false, onlyBody: false }, rules)
 
   if (shouldSkipOnlyBody) return decision.shouldSkip && decision.onlyBody

--- a/test/unit/skipper.js
+++ b/test/unit/skipper.js
@@ -1,0 +1,158 @@
+const { forEach, filter } = require('ramda')
+const { test } = require('ava')
+const { createSkipper } = require('../../src/skipper')
+
+const methods = [
+  'GET',
+  'HEAD',
+  'POST',
+  'PUT',
+  'DELETE',
+  'CONNECT',
+  'OPTIONS',
+  'TRACE',
+  'PATCH'
+]
+
+test('SkipByMethod: Skip all methods for /room route and its children', t => {
+  const rules = [{
+    route: /\/room/,
+    method: /.*/,
+    onlyBody: false
+  }]
+
+  const skipper = createSkipper(rules)
+
+  forEach(method => (
+    t.true(skipper('/room', method))
+  ), methods)
+})
+
+test('SkipByMethod: Skip only GET method for /room route and its children', t => {
+  const rules = [{
+    route: /\/room/,
+    method: /GET/,
+    onlyBody: false
+  }]
+
+  const skipper = createSkipper(rules)
+  const methodsWithoutGet = filter(method => method !== 'GET', methods)
+
+  t.true(skipper('/room', 'GET'))
+  t.true(skipper('/room/1', 'GET'))
+
+  forEach(method => {
+    t.false(skipper('/room', method))
+    t.false(skipper('/room/1', method))
+  }, methodsWithoutGet)
+})
+
+test('SkipByMethod: Skip only POST method for /room route and its children with multiples rules', t => {
+  const rules = [
+    {
+      route: /\/room/,
+      method: /POST/,
+      onlyBody: false
+    },
+    {
+      route: /\/game/,
+      method: /GET/,
+      onlyBody: false
+    },
+  ]
+
+  const skipper = createSkipper(rules)
+
+  t.true(skipper('/room/1', 'POST'))
+  t.true(skipper('/room/1/player', 'POST'))
+  t.false(skipper('/room/1', 'GET'))
+  t.false(skipper('/room/1/player', 'GET'))
+})
+
+test('SkipByMethod: Skip by method for /room route and its children with rules overwriting', t => {
+  const rules = [
+    {
+      route: /\/room/,
+      method: /POST/,
+      onlyBody: false
+    },
+    {
+      route: /\/room/,
+      method: /GET/,
+      onlyBody: false
+    },
+    {
+      route: /\/player/,
+      method: /.*/,
+      onlyBody: true
+    }
+  ]
+
+  const skipper = createSkipper(rules)
+
+  t.true(skipper('/room/1', 'POST'))
+  t.false(skipper('/room/1/player', 'POST'))
+})
+
+test('SkipByRoute: Skip all methods for specific /room/:id route', t => {
+  const rules = [{
+    route: /\/room\/[0-9](?!\/.*)/,
+    method: /.*/,
+    onlyBody: false
+  }]
+
+  const skipper = createSkipper(rules)
+
+  forEach(method => {
+    t.false(skipper('/room', method))
+    t.true(skipper('/room/1', method))
+  }, methods)
+})
+
+test('SkipByRoute: Skip only GET method for /player route and its children', t => {
+  const rules = [{
+    route: /\/player/,
+    method: /GET/,
+    onlyBody: false
+  }]
+
+  const skipper = createSkipper(rules)
+  const methodsWithoutGet = filter(method => method !== 'GET', methods)
+
+  t.true(skipper('/player', 'GET'))
+  t.true(skipper('/player/1', 'GET'))
+
+  forEach(method => {
+    t.false(skipper('/player', method))
+    t.false(skipper('/player/1', method))
+  }, methodsWithoutGet)
+})
+
+test('SkipByRoute: Skip only GET method for /player route and its children', t => {
+  const rules = [{
+    route: /\/player/,
+    method: /GET/,
+    onlyBody: false
+  }]
+
+  const skipper = createSkipper(rules)
+  const methodsWithoutGet = filter(method => method !== 'GET', methods)
+
+  t.true(skipper('/player', 'GET'))
+  t.true(skipper('/player/1', 'GET'))
+
+  forEach(method => {
+    t.false(skipper('/player', method))
+    t.false(skipper('/player/1', method))
+  }, methodsWithoutGet)
+})
+
+test('EmptySkipRule: Do not skip any log', t => {
+  const rules = []
+
+  const skipper = createSkipper(rules)
+
+  forEach(method => (
+   t.false(skipper('/room', method))
+  ), methods)
+})


### PR DESCRIPTION
Add new engine for skipe-rules: the skipper.

The skipper will be the engine that will responsible to skip logs
by method and/or route. Also, skipper can skip only the body property from
a log.