### PR TITLE
chore: move iron-mask back to prod dependencies

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "escriba",
-  "version": "2.1.2",
+  "version": "2.2.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -2990,7 +2990,6 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/iron-mask/-/iron-mask-1.0.2.tgz",
       "integrity": "sha1-3AADhYBVh4c3rDz8COxc95554A8=",
-      "dev": true,
       "requires": {
         "ramda": "0.23.0"
       }

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
   "dependencies": {
     "circular-json": "0.5.5",
     "cuid": "^1.3.8",
+    "iron-mask": "1.0.2",
     "moment-timezone": "^0.5.13",
     "pokeprop": "^1.0.0",
     "ramda": "^0.23.0"
@@ -35,7 +36,6 @@
     "eslint-plugin-node": "^4.2.2",
     "eslint-plugin-promise": "^3.5.0",
     "eslint-plugin-standard": "^3.0.1",
-    "iron-mask": "^1.0.2",
     "log4js": "^3.0.0",
     "mask-json": "^1.0.2",
     "nyc": "^13.0.0",


### PR DESCRIPTION
Because `iron-mask` is a dependency which is used
by default, it should be included in the `dependencies`
block of the `package.json`.