### PR TITLE
respose-logger: add root req and res object props

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "escriba",
-  "version": "2.3.0",
+  "version": "2.4.0",
   "description": "Logging with steroids",
   "main": "src/index.js",
   "scripts": {

--- a/src/response-logger.js
+++ b/src/response-logger.js
@@ -12,9 +12,19 @@ const buildResLog = propsToLog => ({ req, res }) => {
   const env = pickProperties(process.env, propsToLog)
 
   const resProps = pickProperties(res, propsToLog)
+
+  const reqResProps = pickProperties(
+    {
+      req,
+      res
+    },
+    propsToLog
+  )
+
   return R.mergeAll([
     reqProps,
     resProps,
+    reqResProps,
     {
       level,
       from: 'response',


### PR DESCRIPTION
With this PR we can now pick props to log from both `req` and `res` express' objects without overriding each other.
Example: if I try to log just the `body` property from `req` and `res`, escriba is only going to log from the latter. So, in order to log from `req` as well, now I can just pass `req.body` and it'll be logged under a `req` object.