### PR TITLE
Adiciona propriedade propMaxLength ao httpConf

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,7 +107,11 @@ const { httpLogger } = escriba({
         method: /OPTIONS/,
         onlyBody: false
       }
-    ]
+    ],
+    maxPropLength: {
+      body: 2048,
+      url: 1024
+    }
   }
 })
 
@@ -128,6 +132,8 @@ logger.info('some controller information', { id: req.id })
 ```
 
 Also it's possible to skip logs or only the body property through skipRules, in the example we are skiping logs from route `/status` for `all methods` and skiping the `body` property from routes that ends with `.csv` or `.xlsx`.
+
+The `maxPropLength` attribute is responsible to limit the number of characters for certain properties if they exist within `propsTolog` definition.
 
 ## Masks
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "escriba",
-  "version": "2.4.0",
+  "version": "2.5.0",
   "description": "Logging with steroids",
   "main": "src/index.js",
   "scripts": {

--- a/src/http-logger.js
+++ b/src/http-logger.js
@@ -4,7 +4,13 @@ const { createResponseLogger } = require('./response-logger')
 const { createRequestLogger } = require('./request-logger')
 const { createSkipper } = require('./skipper')
 
-const prepareConfigProps = ({ envToLog, propsToLog, skipRules, logIdPath }) => {
+const prepareConfigProps = ({
+  envToLog,
+  propsToLog,
+  skipRules,
+  logIdPath,
+  propMaxLength
+}) => {
   const defaultPropsToLog = R.defaultTo({}, propsToLog)
   const defaultSkipRules = R.defaultTo([], skipRules)
   const defaultEnvToLog = R.defaultTo([], envToLog)
@@ -24,7 +30,8 @@ const prepareConfigProps = ({ envToLog, propsToLog, skipRules, logIdPath }) => {
   return {
     propsToLog: propsToLogConfig,
     skipRules: defaultSkipRules,
-    logIdPath: defaultLogIdPath
+    logIdPath: defaultLogIdPath,
+    propMaxLength
   }
 }
 
@@ -37,11 +44,27 @@ const middleware = (requestLogger, responseLogger, logIdPath, skipper) => (req, 
 }
 
 const httpLogger = (logger, messageBuilder, config) => {
-  const { propsToLog, skipRules, logIdPath } = prepareConfigProps(config)
+  const {
+    propsToLog,
+    skipRules,
+    logIdPath,
+    propMaxLength
+  } = prepareConfigProps(config)
   const { request, response } = propsToLog
   const skipper = createSkipper(skipRules)
-  const reqLogger = createRequestLogger(logger, messageBuilder, request)
-  const resLogger = createResponseLogger(logger, messageBuilder, response, skipper)
+  const reqLogger = createRequestLogger({
+    logger,
+    messageBuilder,
+    request,
+    propMaxLength
+  })
+  const resLogger = createResponseLogger({
+    logger,
+    messageBuilder,
+    response,
+    skipper,
+    propMaxLength
+  })
   return middleware(reqLogger, resLogger, logIdPath, skipper)
 }
 

--- a/src/request-logger.js
+++ b/src/request-logger.js
@@ -1,8 +1,10 @@
 const R = require('ramda')
 const { pickProperties, stringify } = require('./utils')
+const { filterLargeProp } = require('./utils')
 
-const buildRequestLog = propsToLog => req => {
+const buildRequestLog = (propsToLog, propLengthLimit) => req => {
   const reqProps = pickProperties(req, propsToLog)
+  reqProps.body = filterLargeProp(reqProps, 'body', propLengthLimit)
   const env = pickProperties(process.env, propsToLog)
   const headerProps = pickProperties(req.headers, propsToLog)
   return R.mergeAll([
@@ -16,8 +18,13 @@ const buildRequestLog = propsToLog => req => {
   ])
 }
 
-const requestLogger = (logger, messageBuilder, propsToLog) => (req) => {
-  const log = R.pipe(buildRequestLog(propsToLog), messageBuilder)(req)
+const requestLogger = ({
+  logger,
+  messageBuilder,
+  request: propsToLog,
+  propLengthLimit
+}) => (req) => {
+  const log = R.pipe(buildRequestLog(propsToLog, propLengthLimit), messageBuilder)(req)
   req.startTime = log.startTime
   logger.info(stringify(log))
   return log

--- a/src/request-logger.js
+++ b/src/request-logger.js
@@ -1,10 +1,11 @@
 const R = require('ramda')
 const { pickProperties, stringify } = require('./utils')
-const { filterLargeProp } = require('./utils')
+const { filterLargeProp, filterLargeUrl } = require('./utils')
 
-const buildRequestLog = (propsToLog, propLengthLimit) => req => {
+const buildRequestLog = (propsToLog, propMaxLength = {}) => req => {
   const reqProps = pickProperties(req, propsToLog)
-  reqProps.body = filterLargeProp(reqProps, 'body', propLengthLimit)
+  reqProps.body = filterLargeProp(reqProps.body, propMaxLength.body)
+  reqProps.url = filterLargeUrl(reqProps.url, propMaxLength.url)
   const env = pickProperties(process.env, propsToLog)
   const headerProps = pickProperties(req.headers, propsToLog)
   return R.mergeAll([
@@ -22,9 +23,9 @@ const requestLogger = ({
   logger,
   messageBuilder,
   request: propsToLog,
-  propLengthLimit
+  propMaxLength
 }) => (req) => {
-  const log = R.pipe(buildRequestLog(propsToLog, propLengthLimit), messageBuilder)(req)
+  const log = R.pipe(buildRequestLog(propsToLog, propMaxLength), messageBuilder)(req)
   req.startTime = log.startTime
   logger.info(stringify(log))
   return log

--- a/src/utils.js
+++ b/src/utils.js
@@ -50,10 +50,24 @@ const isMaskJsonVendor = vendor => {
 const isVendorMaskValid = maskVendor =>
   isIronMaskVendor(maskVendor) || isMaskJsonVendor(maskVendor)
 
-const filterLargeProp = (object, prop, propLengthLimit) => {
-  if (!object[prop]) return
+const filterLargeProp = (prop, propLengthLimit) => {
+  if (!prop) return
 
-  return JSON.stringify(object[prop]).length > propLengthLimit ? {} : object[prop]
+  if (propLengthLimit === undefined) return prop
+
+  const setDefaultProp = () => Array.isArray(prop) ? [] : {}
+
+  return JSON.stringify(prop).length > propLengthLimit ? setDefaultProp() : prop
+}
+
+const filterLargeUrl = (url, urlLengthLimit) => {
+  if (!url) return
+
+  if (urlLengthLimit === undefined) return url
+
+  const truncateUrl = () => url.substring(0, urlLengthLimit - 3) + '...'
+
+  return url.length > urlLengthLimit ? truncateUrl(url) : url
 }
 
 module.exports = {
@@ -65,5 +79,6 @@ module.exports = {
   isMaskJsonVendor,
   isVendorMaskValid,
   stringify,
-  filterLargeProp
+  filterLargeProp,
+  filterLargeUrl
 }

--- a/src/utils.js
+++ b/src/utils.js
@@ -50,6 +50,12 @@ const isMaskJsonVendor = vendor => {
 const isVendorMaskValid = maskVendor =>
   isIronMaskVendor(maskVendor) || isMaskJsonVendor(maskVendor)
 
+const filterLargeProp = (object, prop, propLengthLimit) => {
+  if (!object[prop]) return
+
+  return JSON.stringify(object[prop]).length > propLengthLimit ? {} : object[prop]
+}
+
 module.exports = {
   parseStringToJSON,
   pickProperties,
@@ -58,5 +64,6 @@ module.exports = {
   isIronMaskVendor,
   isMaskJsonVendor,
   isVendorMaskValid,
-  stringify
+  stringify,
+  filterLargeProp
 }

--- a/test/unit/request-logger.js
+++ b/test/unit/request-logger.js
@@ -1,0 +1,88 @@
+const { test } = require('ava')
+const log4js = require('log4js')
+const ironMask = require('iron-mask')
+
+const { createRequestLogger } = require('../../src/request-logger')
+const { createMessageBuilder } = require('../../src/message-builder.js')
+const { createLogger } = require('../../src/logger')
+
+let reqLogger = {}
+
+test.before(() => {
+  const loggerEngine = log4js.configure({
+    appenders: {
+      api: {
+        type: 'console',
+        layout: {
+          type: 'pattern',
+          pattern: '%m'
+        }
+      }
+    },
+    categories: { default: { appenders: ['api'], level: 'info' } }
+  })
+
+  const sensitive = {
+    password: {
+      paths: ['message.password'],
+      pattern: /\w.*/g,
+      replacer: '*'
+    }
+  }
+
+  const messageBuilder = createMessageBuilder(ironMask.create(sensitive), 'test')
+  const logger = loggerEngine.getLogger()
+
+  const request = [
+    'id',
+    'method',
+    'url',
+    'body',
+    'user-agent',
+    'env'
+  ]
+  reqLogger = createRequestLogger({
+    logger,
+    messageBuilder,
+    request,
+    propLengthLimit: 15
+  })
+})
+
+test('should return body content', t => {
+  const expectedBody = {
+    foo: 'bar'
+  }
+
+  const req = {
+    id: 123,
+    body: {
+      foo: 'bar'
+    },
+    method: 'POST',
+    url: 'https://foobar.com',
+    user_agent: 'pagarme-ruby',
+    env: {}
+  }
+
+  const { body } = reqLogger(req)
+  t.deepEqual(body, expectedBody)
+})
+
+test('should return empty object', t => {
+  const req = {
+    id: 123,
+    body: {
+      foo: 'bar',
+      bar: 'foo'
+    },
+    method: 'POST',
+    url: 'https://foobar.com',
+    user_agent: 'pagarme-ruby',
+    env: {}
+  }
+
+  const { body } = reqLogger(req)
+
+  t.deepEqual(body, {})
+})

--- a/test/unit/request-logger/index.js
+++ b/test/unit/request-logger/index.js
@@ -2,9 +2,8 @@ const { test } = require('ava')
 const log4js = require('log4js')
 const ironMask = require('iron-mask')
 
-const { createRequestLogger } = require('../../src/request-logger')
-const { createMessageBuilder } = require('../../src/message-builder.js')
-const { createLogger } = require('../../src/logger')
+const { createRequestLogger } = require('../../../src/request-logger')
+const { createMessageBuilder } = require('../../../src/message-builder.js')
 
 let reqLogger = {}
 
@@ -45,7 +44,6 @@ test.before(() => {
     logger,
     messageBuilder,
     request,
-    propLengthLimit: 15
   })
 })
 
@@ -67,22 +65,4 @@ test('should return body content', t => {
 
   const { body } = reqLogger(req)
   t.deepEqual(body, expectedBody)
-})
-
-test('should return empty object', t => {
-  const req = {
-    id: 123,
-    body: {
-      foo: 'bar',
-      bar: 'foo'
-    },
-    method: 'POST',
-    url: 'https://foobar.com',
-    user_agent: 'pagarme-ruby',
-    env: {}
-  }
-
-  const { body } = reqLogger(req)
-
-  t.deepEqual(body, {})
 })

--- a/test/unit/request-logger/prop-max-length-attribute.js
+++ b/test/unit/request-logger/prop-max-length-attribute.js
@@ -1,0 +1,122 @@
+const { test } = require('ava')
+const log4js = require('log4js')
+const ironMask = require('iron-mask')
+
+const { createRequestLogger } = require('../../../src/request-logger')
+const { createMessageBuilder } = require('../../../src/message-builder.js')
+
+let reqLogger = {}
+
+test.before(() => {
+  const loggerEngine = log4js.configure({
+    appenders: {
+      api: {
+        type: 'console',
+        layout: {
+          type: 'pattern',
+          pattern: '%m'
+        }
+      }
+    },
+    categories: { default: { appenders: ['api'], level: 'info' } }
+  })
+
+  const sensitive = {
+    password: {
+      paths: ['message.password'],
+      pattern: /\w.*/g,
+      replacer: '*'
+    }
+  }
+
+  const messageBuilder = createMessageBuilder(ironMask.create(sensitive), 'test')
+  const logger = loggerEngine.getLogger()
+
+  const request = [
+    'id',
+    'method',
+    'url',
+    'body',
+    'user-agent',
+    'env'
+  ]
+  reqLogger = createRequestLogger({
+    logger,
+    messageBuilder,
+    request,
+    propMaxLength: {
+      body: 15,
+      url: 15
+    }
+  })
+})
+
+test('should return body content', t => {
+  const expectedBody = {
+    foo: 'bar'
+  }
+
+  const req = {
+    id: 123,
+    body: {
+      foo: 'bar'
+    },
+    method: 'POST',
+    url: 'https://foobar.com',
+    user_agent: 'pagarme-ruby',
+    env: {}
+  }
+
+  const { body } = reqLogger(req)
+  t.deepEqual(body, expectedBody)
+})
+
+test('should return empty object', t => {
+  const req = {
+    id: 123,
+    body: {
+      foo: 'bar',
+      bar: 'foo'
+    },
+    method: 'POST',
+    url: 'https://foobar.com',
+    user_agent: 'pagarme-ruby',
+    env: {}
+  }
+
+  const { body } = reqLogger(req)
+
+  t.deepEqual(body, {})
+})
+
+test('should return empty object', t => {
+  const req = {
+    id: 123,
+    body: [{
+      foo: 'bar',
+      bar: 'foo'
+    }],
+    method: 'POST',
+    url: 'https://foobar.com',
+    user_agent: 'pagarme-ruby',
+    env: {}
+  }
+
+  const { body } = reqLogger(req)
+
+  t.deepEqual(body, [])
+})
+
+test('should return url without query string parameters', t => {
+  const req = {
+    id: 123,
+    url: '/myurl?prop1=value1&prop2=value2',
+    method: 'POST',
+    user_agent: 'pagarme-ruby',
+    env: {}
+  }
+
+  const { url } = reqLogger(req)
+
+  t.deepEqual(url, '/myurl?prop1...')
+})

--- a/test/unit/response-logger/index.js
+++ b/test/unit/response-logger/index.js
@@ -1,0 +1,43 @@
+const { test } = require('ava')
+
+const { buildResLog } = require('../../../src/response-logger')
+
+let buildLogResult = {}
+
+test.before(() => {
+  const propsToLog = [
+    'id',
+    'method',
+    'url',
+    'body',
+    'user-agent',
+    'env'
+  ]
+
+  buildLogResult = buildResLog(propsToLog)
+})
+
+test('should return body content', t => {
+  const expectedBody = {
+    foo: 'bar'
+  }
+
+  const req = {
+  }
+
+  const res = {
+    statusCode: 200,
+    id: 123,
+    body: {
+      foo: 'bar'
+    },
+    method: 'POST',
+    url: 'https://foobar.com',
+    user_agent: 'pagarme-ruby',
+    env: {}
+  }
+
+  const { body } = buildLogResult({ req, res })
+
+  t.deepEqual(body, expectedBody)
+})

--- a/test/unit/response-logger/prop-max-length-attribute.js
+++ b/test/unit/response-logger/prop-max-length-attribute.js
@@ -1,0 +1,114 @@
+const { test } = require('ava')
+
+const { buildResLog } = require('../../../src/response-logger')
+
+let buildLogResult = {}
+
+test.before(() => {
+  const propsToLog = [
+    'id',
+    'method',
+    'url',
+    'body',
+    'user-agent',
+    'env'
+  ]
+
+  const propMaxLength = {
+    body: 15,
+    url: 15
+  }
+
+  buildLogResult = buildResLog(propsToLog, propMaxLength)
+})
+
+test('should return body content', t => {
+  const expectedBody = {
+    foo: 'bar'
+  }
+
+  const req = {
+  }
+
+  const res = {
+    statusCode: 200,
+    id: 123,
+    body: {
+      foo: 'bar'
+    },
+    method: 'POST',
+    url: 'https://foobar.com',
+    user_agent: 'pagarme-ruby',
+    env: {}
+  }
+
+  const { body } = buildLogResult({ req, res })
+
+  t.deepEqual(body, expectedBody)
+})
+
+test('should return empty object', t => {
+  const req = {
+  }
+
+  const res = {
+    statusCode: 200,
+    id: 123,
+    body: {
+      foo: 'bar',
+      bar: 'foo'
+    },
+    method: 'POST',
+    url: 'https://foobar.com',
+    user_agent: 'pagarme-ruby',
+    env: {}
+  }
+
+  const { body } = buildLogResult({ req, res })
+
+  t.deepEqual(body, {})
+})
+
+test('should return empty array', t => {
+  const req = {
+  }
+
+  const res = {
+    statusCode: 200,
+    id: 123,
+    body: [{
+      foo: 'bar',
+      bar: 'foo'
+    }],
+    method: 'POST',
+    url: 'https://foobar.com',
+    user_agent: 'pagarme-ruby',
+    env: {}
+  }
+
+  const { body } = buildLogResult({ req, res })
+
+  t.deepEqual(body, [])
+})
+
+test('should return url without query string parameters', t => {
+  const req = {
+    url: '/myurl?prop1=value1&prop2=value2'
+  }
+
+  const res = {
+    statusCode: 200,
+    id: 123,
+    body: {
+      foo: 'bar',
+      bar: 'foo'
+    },
+    method: 'POST',
+    user_agent: 'pagarme-ruby',
+    env: {}
+  }
+
+  const { url } = buildLogResult({ req, res })
+
+  t.deepEqual(url, '/myurl?prop1...')
+})


### PR DESCRIPTION
## Description

Add `maxLengthProp`property that will handle the max character length for a given attribute.

Currently there are two main use cases:

**1 - When the body attribute exceeds it's limit:**

```
  body: {
      foo: 'bar',
      bar: 'foo'
  },

```

it will be replaced by:

`body: { }`


**2 - When the url attribute exceeds it's limit:**

`/myurl?prop1=value1&prop2=value2`

it will be replaced by:

`/myurl?prop1***`  (just an example, since it may vary depending on the url's limit) 
