### PR TITLE
2.6.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "escriba",
-  "version": "2.6.0",
+  "version": "2.6.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "escriba",
-  "version": "2.6.0",
+  "version": "2.6.1",
   "description": "Logging with steroids",
   "main": "src/index.js",
   "scripts": {


### PR DESCRIPTION
Bump da versão para permitir a publicação do conteúdo introduzido na versão 2.6.0, que foi removida do NPM para validação profunda de uma suspeita de falha de segurança.
A validação que fizemos não apresentou nenhum risco na biblioteca.