### PR TITLE
Support custom options at message-builder

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "escriba",
-  "version": "2.6.1",
+  "version": "2.7.0",
   "description": "Logging with steroids",
   "main": "src/index.js",
   "scripts": {

--- a/src/message-builder.js
+++ b/src/message-builder.js
@@ -14,7 +14,7 @@ const generateDefaultProps = (service, integrations) => applyIntegrations({
 const filterMessage = R.filter(prop => !R.isNil(prop))
 
 const builder = (messageMasker, service, integrations) => (message, propsToLog) => (
-  filterMessage(messageMasker(R.merge(message, generateDefaultProps(service, integrations))))
+  filterMessage(messageMasker(R.merge(generateDefaultProps(service, integrations), message)))
 )
 
 module.exports = { createMessageBuilder: builder }

--- a/test/unit/message-builder.js
+++ b/test/unit/message-builder.js
@@ -1,4 +1,3 @@
-const R = require('ramda')
 const test = require('ava')
 const { createMessageBuilder } = require('../../src/message-builder')
 
@@ -10,8 +9,24 @@ test.before(() => {
 })
 
 test('messageBuilder: create message with a valid JSON object', t => {
-  const { message, service, level } = messageBuilder({ message: 'Papyrus', level: 'info' })
+  const { message, service, level } = messageBuilder({
+    message: 'Papyrus',
+    level: 'info'
+  })
+
   t.is(message, 'Papyrus')
   t.is(service, 'test')
+  t.is(level, 'info')
+})
+
+test('messageBuilder: create message with a valid JSON object and custom service', t => {
+  const { message, service, level } = messageBuilder({
+    message: 'Papyrus',
+    level: 'info',
+    service: 'custom-test'
+  })
+
+  t.is(message, 'Papyrus')
+  t.is(service, 'custom-test')
   t.is(level, 'info')
 })


### PR DESCRIPTION
# Description

This PR aims to update how we merge the logger options with the message options, enabling it to be overwritten by the logger message options.

The main example is enabling the overwrite when logging a specific message setting a custom service name.