### PR TITLE
Add new prop type parsing capability

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,6 +111,15 @@ const { httpLogger } = escriba({
     propMaxLength: {
       body: 2048,
       url: 1024
+    },
+    propsToParse: {
+      request: {
+         'id': String,
+         'body.document_number': Number,
+      },
+      response: {
+         'body.customer.id': Number
+      }
     }
   }
 })
@@ -134,6 +143,8 @@ logger.info('some controller information', { id: req.id })
 Also it's possible to skip logs or only the body property through skipRules, in the example we are skiping logs from route `/status` for `all methods` and skiping the `body` property from routes that ends with `.csv` or `.xlsx`.
 
 The `propMaxLength` attribute is responsible to limit the number of characters for certain properties if they exist within `propsTolog` definition.
+
+The `propsToParse` attribute is responsible to parse any atribute based on a path, the parsing works by providing a valid javascript native Function (e.g String, Number etc).
 
 ## Masks
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "escriba",
-  "version": "2.7.0",
+  "version": "2.8.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "escriba",
-  "version": "2.6.1",
+  "version": "2.7.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -4798,7 +4798,7 @@
         },
         "resolve-from": {
           "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-4.0.0.tgz",
+          "resolved": false,
           "integrity": "sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==",
           "dev": true
         },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "escriba",
-  "version": "2.7.0",
+  "version": "2.8.0",
   "description": "Logging with steroids",
   "main": "src/index.js",
   "scripts": {

--- a/src/http-logger.js
+++ b/src/http-logger.js
@@ -9,7 +9,8 @@ const prepareConfigProps = ({
   propsToLog,
   skipRules,
   logIdPath,
-  propMaxLength
+  propMaxLength,
+  propsToParse
 }) => {
   const defaultPropsToLog = R.defaultTo({}, propsToLog)
   const defaultSkipRules = R.defaultTo([], skipRules)
@@ -31,7 +32,8 @@ const prepareConfigProps = ({
     propsToLog: propsToLogConfig,
     skipRules: defaultSkipRules,
     logIdPath: defaultLogIdPath,
-    propMaxLength
+    propMaxLength,
+    propsToParse
   }
 }
 
@@ -48,7 +50,8 @@ const httpLogger = (logger, messageBuilder, config) => {
     propsToLog,
     skipRules,
     logIdPath,
-    propMaxLength
+    propMaxLength,
+    propsToParse
   } = prepareConfigProps(config)
   const { request, response } = propsToLog
   const skipper = createSkipper(skipRules)
@@ -56,14 +59,16 @@ const httpLogger = (logger, messageBuilder, config) => {
     logger,
     messageBuilder,
     request,
-    propMaxLength
+    propMaxLength,
+    propsToParse
   })
   const resLogger = createResponseLogger({
     logger,
     messageBuilder,
     response,
     skipper,
-    propMaxLength
+    propMaxLength,
+    propsToParse
   })
   return middleware(reqLogger, resLogger, logIdPath, skipper)
 }

--- a/src/utils.js
+++ b/src/utils.js
@@ -70,6 +70,26 @@ const filterLargeUrl = (url, urlLengthLimit) => {
   return url.length > urlLengthLimit ? truncateUrl(url) : url
 }
 
+const parsePropsType = (reqProps, propsType) => {
+  const propsTypeKeys = R.keys(propsType)
+
+  if (propsTypeKeys.length === 0) {
+    return reqProps
+  }
+
+  return propsTypeKeys.reduce((acc, key) => {
+    const propPath = key.split('.')
+    const reqProp = R.path(propPath, acc)
+
+    if (reqProp !== undefined) {
+      const propTypeFunction = propsType[key]
+      return R.assocPath(propPath, propTypeFunction(reqProp), acc)
+    }
+
+    return acc
+  }, reqProps)
+}
+
 module.exports = {
   parseStringToJSON,
   pickProperties,
@@ -80,5 +100,6 @@ module.exports = {
   isVendorMaskValid,
   stringify,
   filterLargeProp,
-  filterLargeUrl
+  filterLargeUrl,
+  parsePropsType
 }

--- a/test/unit/request-logger/prop-max-length-attribute.js
+++ b/test/unit/request-logger/prop-max-length-attribute.js
@@ -89,24 +89,6 @@ test('should return empty object', t => {
   t.deepEqual(body, {})
 })
 
-test('should return empty object', t => {
-  const req = {
-    id: 123,
-    body: [{
-      foo: 'bar',
-      bar: 'foo'
-    }],
-    method: 'POST',
-    url: 'https://foobar.com',
-    user_agent: 'pagarme-ruby',
-    env: {}
-  }
-
-  const { body } = reqLogger(req)
-
-  t.deepEqual(body, [])
-})
-
 test('should return url without query string parameters', t => {
   const req = {
     id: 123,

--- a/test/unit/request-logger/prop-type-attribute.js
+++ b/test/unit/request-logger/prop-type-attribute.js
@@ -42,7 +42,7 @@ test('should return parsed body properties', t => {
   const propMaxLength = {}
   const propsToParse = {
     request: {
-      'body.id': parseInt,
+      'body.id': Number,
       'body.keys': String
     }
   }

--- a/test/unit/request-logger/prop-type-attribute.js
+++ b/test/unit/request-logger/prop-type-attribute.js
@@ -1,0 +1,75 @@
+const test = require('ava')
+const log4js = require('log4js')
+const ironMask = require('iron-mask')
+
+const { createRequestLogger } = require('../../../src/request-logger')
+const { createMessageBuilder } = require('../../../src/message-builder.js')
+
+const loggerEngine = log4js.configure({
+  appenders: {
+    api: {
+      type: 'console',
+      layout: {
+        type: 'pattern',
+        pattern: '%m'
+      }
+    }
+  },
+  categories: { default: { appenders: ['api'], level: 'info' } }
+})
+
+const sensitive = {
+  password: {
+    paths: ['message.password'],
+    pattern: /\w.*/g,
+    replacer: '*'
+  }
+}
+
+const messageBuilder = createMessageBuilder(ironMask.create(sensitive), 'test')
+const logger = loggerEngine.getLogger()
+
+const request = [
+  'id',
+  'method',
+  'url',
+  'body',
+  'user-agent',
+  'env'
+]
+
+test('should return parsed body properties', t => {
+  const propMaxLength = {}
+  const propsToParse = {
+    request: {
+      'body.id': parseInt,
+      'body.keys': String
+    }
+  }
+
+  const reqLogger = createRequestLogger({
+    logger,
+    messageBuilder,
+    request,
+    propMaxLength,
+    propsToParse
+  })
+
+  const expectedBody = {
+    id: 123,
+    keys: '1,2,3',
+    foo: 'bar',
+    bar: 'foo'
+  }
+
+  const req = {
+    body: {
+      id: '123',
+      keys: [1, 2, 3],
+      foo: 'bar',
+      bar: 'foo'
+    }
+  }
+  const { body } = reqLogger(req)
+  t.deepEqual(body, expectedBody)
+})

--- a/test/unit/response-logger/prop-type-attribute.js
+++ b/test/unit/response-logger/prop-type-attribute.js
@@ -1,0 +1,55 @@
+const test = require('ava')
+
+const { buildResLog } = require('../../../src/response-logger')
+
+let buildLogResult = {}
+
+const propsToLog = [
+  'id',
+  'method',
+  'url',
+  'body',
+  'user-agent',
+  'env'
+]
+
+const propsToParse = {
+  response: {
+    'body.foo': String,
+    'id': parseInt
+  }
+}
+
+buildLogResult = buildResLog(propsToLog, {}, propsToParse)
+
+test('should return parsed body content', t => {
+  const expectedResponse = {
+    id: 123,
+    body: {
+      foo: '42'
+    },
+    method: 'POST',
+    from: 'response',
+    env: {},
+    level: 'info',
+    url: undefined
+  }
+
+  const req = {
+  }
+
+  const res = {
+    id: 123,
+    body: {
+      foo: 42
+    },
+    method: 'POST',
+    from: 'response',
+    env: {},
+    level: 'info',
+  }
+
+  const response = buildLogResult({ req, res })
+
+  t.deepEqual(response, expectedResponse)
+})

--- a/test/unit/utils.js
+++ b/test/unit/utils.js
@@ -80,3 +80,63 @@ test('isMaskJsonVendor: with a mask-json instance', t => {
 test('isMaskJsonVendor: with an iron-mask instance', t => {
   t.is(utils.isMaskJsonVendor(ironMask), false)
 })
+
+test('parsePropsType: with a valid propsToParse parameter', t => {
+  const reqProps = {
+    body: {
+      id: 123
+    }
+  }
+
+  const propsToParse = {
+    'body.id': String
+  }
+
+  const expectedAssertion = {
+    body: {
+      id: '123'
+    }
+  }
+
+  t.deepEqual(utils.parsePropsType(reqProps, propsToParse), expectedAssertion)
+})
+
+test('parsePropsType: with an invalid propsToParse parameter', t => {
+  const reqProps = {
+    body: {
+      id: 123
+    }
+  }
+
+  const propsToParse = {
+    'body.foobar': String
+  }
+
+  const expectedAssertion = {
+    body: {
+      id: 123
+    }
+  }
+
+  t.deepEqual(utils.parsePropsType(reqProps, propsToParse), expectedAssertion)
+})
+
+test('parsePropsType: with a falsy parameter value', t => {
+  const reqProps = {
+    body: {
+      amount: 0
+    }
+  }
+
+  const propsToParse = {
+    'body.amount': String
+  }
+
+  const expectedAssertion = {
+    body: {
+      amount: '0'
+    }
+  }
+
+  t.deepEqual(utils.parsePropsType(reqProps, propsToParse), expectedAssertion)
+})


### PR DESCRIPTION
## Description

Adds new prop type parsing capability to both request and response objects.

The idea is that if you want to change the log property's type but can't change the request/response contract of your service/api  you can use this options instead!
