### PR TITLE
Corrige compatibilidade do parâmetro "url" com o Express Router

### DIFF
--- a/src/request-logger.js
+++ b/src/request-logger.js
@@ -13,6 +13,8 @@ const buildRequestLog = (
 ) => req => {
   const reqProps = pickProperties(req, propsToLog)
   reqProps.body = filterLargeProp(reqProps.body, propMaxLength.body)
+
+  reqProps.url = req.originalUrl || req.url
   reqProps.url = filterLargeUrl(reqProps.url, propMaxLength.url)
   const env = pickProperties(process.env, propsToLog)
   const headerProps = pickProperties(req.headers, propsToLog)

--- a/src/response-logger.js
+++ b/src/response-logger.js
@@ -25,6 +25,7 @@ const buildResLog = (
   const resProps = pickProperties(res, propsToLog)
 
   resProps.body = filterLargeProp(resProps.body, propMaxLength.body)
+  reqProps.url = req.originalUrl || req.url
   reqProps.url = filterLargeUrl(reqProps.url, propMaxLength.url)
 
   const reqParsedProps = parsePropsType(reqProps, propsToParse.response)

--- a/test/unit/request-logger/index.js
+++ b/test/unit/request-logger/index.js
@@ -43,7 +43,7 @@ test.before(() => {
   reqLogger = createRequestLogger({
     logger,
     messageBuilder,
-    request,
+    request
   })
 })
 
@@ -65,4 +65,21 @@ test('should return body content', t => {
 
   const { body } = reqLogger(req)
   t.deepEqual(body, expectedBody)
+})
+
+test('should return the correct url', t => {
+  const req = {
+    url: 'https://url.com',
+    originalUrl: 'https://original-url.com'
+  }
+
+  let log = reqLogger(req)
+
+  t.is(log.url, req.originalUrl)
+
+  req.originalUrl = ''
+
+  log = reqLogger(req)
+
+  t.is(log.url, req.url)
 })

--- a/test/unit/response-logger/index.js
+++ b/test/unit/response-logger/index.js
@@ -41,3 +41,28 @@ test('should return body content', t => {
 
   t.deepEqual(body, expectedBody)
 })
+
+test('should return the correct url', t => {
+  const req = {
+    url: 'https://url.com',
+    originalUrl: 'https://original-url.com'
+  }
+
+  const res = {
+    statusCode: 200,
+    id: 123,
+    method: 'POST',
+    user_agent: 'pagarme-ruby',
+    env: {}
+  }
+
+  let log = buildLogResult({ req, res })
+
+  t.is(log.url, req.originalUrl)
+
+  req.originalUrl = ''
+
+  log = buildLogResult({ req, res })
+
+  t.is(log.url, req.url)
+})


### PR DESCRIPTION
Sem o Express Router, o parâmetro `url` é logado corretamente, e o parâmetro `originalUrl` também:
![image](https://user-images.githubusercontent.com/18074134/89584819-149c7e80-d813-11ea-9e19-4f70bc29a9b7.png)

Mas com o Express Router, o parâmetro `url` é logado erroneamente na response, mas o `originalUrl` funciona corretamente.

![image](https://user-images.githubusercontent.com/18074134/89584953-59281a00-d813-11ea-91b6-6b8d704e5e1c.png)

Essa alteração se propõe à priorizar o parâmetro `originalUrl`, e caso ele não exista, o parâmetro `url` será logado.
