### PR TITLE
parse: add propsToParse to common logger

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -13,6 +13,7 @@ const escriba = config => {
     loggerEngine,
     sensitive,
     httpConf,
+    loggerConf,
     maskEngine,
     integrations
   } = config
@@ -31,7 +32,7 @@ const escriba = config => {
 
   const messageMasker = createMask(mask, sensitive)
   const messageBuilder = createMessageBuilder(messageMasker, service, integrations)
-  const logger = createLogger(loggerEngine, messageBuilder)
+  const logger = createLogger(loggerEngine, messageBuilder, loggerConf)
   const httpLogger = createHttpLogger(loggerEngine, messageBuilder, httpConf || {})
   return { logger, httpLogger }
 }

--- a/src/logger.js
+++ b/src/logger.js
@@ -1,11 +1,14 @@
 const R = require('ramda')
 const cuid = require('cuid')
 const { stringify } = require('./utils')
+const { parsePropsType } = require('./utils')
 
-const buildLog = messageBuilder => (message, level, additional) => {
+const buildLog = (messageBuilder, loggerConf) => (message, level, additional) => {
   const defaultAdditional = R.defaultTo({}, additional)
+  message = parsePropsType(message, loggerConf.propsToParse)
   const log = messageBuilder(Object.assign(
-    { id: cuid(), message, level }, defaultAdditional
+    { id: cuid(), message, level },
+    defaultAdditional
   ))
   return log
 }
@@ -17,8 +20,8 @@ const createProxyLevels = (buildLog, logger) => {
   )}))
 }
 
-const logger = (vendorLogger, messageBuilder) => (
-  Object.assign({}, ...createProxyLevels(buildLog(messageBuilder), vendorLogger))
+const logger = (vendorLogger, messageBuilder, loggerConf = {}) => (
+  Object.assign({}, ...createProxyLevels(buildLog(messageBuilder, loggerConf), vendorLogger))
 )
 
 module.exports = { createLogger: logger }


### PR DESCRIPTION
## Descricao

Esse PR tem como objetivo adicionar uma camada de parse para o objeto `logger` (seguindo o exemplo do `httpConf`).

Para isso passamos a aceitar mais um atributo no parametro de instanciacao chamado `loggerConf` com o intuito de receber configuracoes especificas pro logger. Esse novo parametro e um objeto e nesse primeiro momento aceitaremos apenas uma configuracao chamada `propsToParse` (seguindo a nomeclatura do `httpConf`), que tem como objetivo fazer o casting de valores.