### PR TITLE
fix: Skipper ignores search params

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,24 @@
+name: Run tests
+
+on:
+  push:
+    branches:
+      - master
+  pull_request:
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+
+    strategy:
+      matrix:
+        node-version: [12.x, 14.x, 15.x, 16.x, 18.x, 19.x]
+
+    steps:
+      - uses: actions/checkout@v3
+      - name: Use Node.js ${{ matrix.node-version }}
+        uses: actions/setup-node@v3
+        with:
+          node-version: ${{ matrix.node-version }}
+      - run: npm install
+      - run: npm test

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "escriba",
-  "version": "2.10.0",
+  "version": "2.11.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "escriba",
-  "version": "2.10.0",
+  "version": "2.11.0",
   "description": "Logging with steroids",
   "main": "src/index.js",
   "scripts": {

--- a/src/http-logger.js
+++ b/src/http-logger.js
@@ -38,7 +38,8 @@ const prepareConfigProps = ({
 }
 
 const middleware = (requestLogger, responseLogger, logIdPath, skipper) => (req, res, next) => {
-  if (skipper(req.url, req.method)) return next()
+  const path = req.originalUrl.replace(/(\?|\#).*$/, '')
+  if (skipper(path, req.method)) return next()
   req.id = R.path(R.split('.', logIdPath), req) || cuid()
   requestLogger(req)
   responseLogger(req, res)

--- a/src/response-logger.js
+++ b/src/response-logger.js
@@ -80,7 +80,8 @@ const captureLog = ({
   const { req, res } = http
   const { write, end } = res
   const chunks = []
-  const shouldSkipChunk = skipper(req.url, req.method, true)
+  const path = req.originalUrl.replace(/(\?|\#).*$/, '')
+  const shouldSkipChunk = skipper(path, req.method, true)
 
   res.write = chunk => {
     if (!shouldSkipChunk) chunks.push(Buffer.from(chunk))


### PR DESCRIPTION
Before this PR, skipper used to try to apply its path rules against `req.url`, which may include search params (?...) and anchor params (#...).

This PR changes that, applying path rules against `req.path` instead.

Also this PR makes tests run at Github Actions.