### PR TITLE
Include ddtags in the logs

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -10,6 +10,7 @@ const { createMessageBuilder } = require('./message-builder')
 const escriba = config => {
   const {
     service,
+    ddtags,
     loggerEngine,
     sensitive,
     httpConf,
@@ -30,7 +31,7 @@ const escriba = config => {
   loadIntegrations(integrations)
 
   const messageMasker = createMask(mask, sensitive)
-  const messageBuilder = createMessageBuilder(messageMasker, service, integrations)
+  const messageBuilder = createMessageBuilder(messageMasker, service, ddtags, integrations)
   const logger = createLogger(loggerEngine, messageBuilder)
   const httpLogger = createHttpLogger(loggerEngine, messageBuilder, httpConf || {})
   return { logger, httpLogger }

--- a/src/message-builder.js
+++ b/src/message-builder.js
@@ -4,8 +4,9 @@ const moment = require('moment-timezone')
 
 const { log: applyIntegrations } = require('./integrations')
 
-const generateDefaultProps = (service, integrations) => applyIntegrations({
+const generateDefaultProps = (service, ddtags, integrations) => applyIntegrations({
   service,
+  ddtags,
   startTime: moment().valueOf(),
   hostname: os.hostname(),
   pid: process.pid
@@ -13,8 +14,8 @@ const generateDefaultProps = (service, integrations) => applyIntegrations({
 
 const filterMessage = R.filter(prop => !R.isNil(prop))
 
-const builder = (messageMasker, service, integrations) => (message, propsToLog) => (
-  filterMessage(messageMasker(R.merge(generateDefaultProps(service, integrations), message)))
+const builder = (messageMasker, service, ddtags, integrations) => (message, propsToLog) => (
+  filterMessage(messageMasker(R.merge(generateDefaultProps(service, ddtags, integrations), message)))
 )
 
 module.exports = { createMessageBuilder: builder }


### PR DESCRIPTION
Esse pull request tem como objetivo realizar o envio do campo ddtags para os logs do datadog.

[Documentação Datadog](https://docs.datadoghq.com/api/latest/logs/)

<img width="1254" height="1017" alt="image" src="https://github.com/user-attachments/assets/49a3252f-580d-479b-a523-35226d9f5d3f" />
